### PR TITLE
同意するを選択後、登録完了画面が出るようにした

### DIFF
--- a/lib/page/login/new_menber_company.dart
+++ b/lib/page/login/new_menber_company.dart
@@ -5,6 +5,7 @@ import 'package:reelproject/page/home/home.dart';
 import 'package:reelproject/provider/changeGeneralCorporation.dart';
 import 'package:provider/provider.dart';
 import 'package:reelproject/overlay/rule/rule_screen.dart'; //オーバレイで表示される画面のファイル
+import 'package:reelproject/component/finishScreen/finishScreen.dart';
 
 class NewMemberCompany extends StatefulWidget {
   const NewMemberCompany({Key? key}) : super(key: key);
@@ -231,7 +232,15 @@ class NewMemberCompanyState extends State<NewMemberCompany> {
                 // ログインボタンが押されたときの処理をここに追加予定
                 Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (context) => Home()),
+                  // MaterialPageRoute(builder: (context) => Home()),
+                  MaterialPageRoute(
+                      builder: (context) => const FinishScreen(
+                          appbarText: "会員登録完了",
+                          appIcon: Icons.task_alt,
+                          finishText: "会員登録が完了いたしました。",
+                          text:
+                              "法人会員登録ありがとうございます。\nこちらで法人確認を行ったあと、法人会員登録完了メールをご登録メールアドレスへと送信いたしますので、メールが届くまで今しばらくお待ちください。\n万が一法人会員登録完了メールが１か月以上届かない場合、お問い合わせホームにてお問い合わせをしていただくと幸いです。",
+                          buttonText: "ログイン画面に戻る")),
                 );
               },
               style: ElevatedButton.styleFrom(

--- a/lib/page/login/new_menber_general.dart
+++ b/lib/page/login/new_menber_general.dart
@@ -5,6 +5,7 @@ import 'package:reelproject/page/home/home.dart';
 import 'package:reelproject/provider/changeGeneralCorporation.dart';
 import 'package:provider/provider.dart';
 import 'package:reelproject/overlay/rule/rule_screen.dart'; //オーバレイで表示される画面のファイル
+import 'package:reelproject/component/finishScreen/finishScreen.dart';
 
 class NewMemberGeneral extends StatefulWidget {
   const NewMemberGeneral({Key? key}) : super(key: key);
@@ -185,7 +186,15 @@ class NewMemberGeneralState extends State<NewMemberGeneral> {
                 // ログインボタンが押されたときの処理をここに追加予定
                 Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (context) => Home()),
+                  // MaterialPageRoute(builder: (context) => Home()),
+                  MaterialPageRoute(
+                      builder: (context) => const FinishScreen(
+                          appbarText: "会員登録完了",
+                          appIcon: Icons.task_alt,
+                          finishText: "会員登録が完了いたしました。",
+                          text:
+                              "会員登録ありがとうございます。\nご登録メールアドレスへご確認メールをお送りしました。\n万が一メールが届かない場合、ご登録メールアドレスが正しいかご確認ください。\nメールアドレスが受け取り可能なものにもかかわらずご確認メールが届かない場合、お問い合わせホームにてお問い合わせをしていただくと幸いです。",
+                          buttonText: "ログイン画面に戻る")),
                 );
               },
               style: ElevatedButton.styleFrom(


### PR DESCRIPTION
## :cyclone: 関連する課題 (issue 番号と課題名)
<!-- #[数字]でリンクすることができる。 -->
- here

## :cyclone: 具体的にやったこと

-同意する選択後、登録完了画面に遷移するようにした（new_menber_general.dart, new_menber_company.dart）

## :cyclone: 確認前のチェック事項

- [ ] 適切なコーディングルールの下で記述がされているか

## :cyclone: 画像や動画 (あれば)

- here

## :cyclone: 課題のうち、やっていないこと（あれば）

- here


## :cyclone: 詰まっている箇所 (あれば)

- here
