### PR TITLE
hinttextを英数字と_のみ使用可に変更

### DIFF
--- a/lib/page/login/new_menber_general.dart
+++ b/lib/page/login/new_menber_general.dart
@@ -45,7 +45,8 @@ class NewMemberGeneralState extends State<NewMemberGeneral> {
             const Padding(
               padding: EdgeInsets.all(5.0),
             ),
-            const TextEnterBox(label: 'ユーザー名', hinttext: '例：高知太郎', width: 300),
+            const TextEnterBox(
+                label: 'ユーザー名', hinttext: '英数字と_のみ使用可', width: 300),
             const Padding(
               padding: EdgeInsets.all(10.0),
             ),


### PR DESCRIPTION
## :cyclone: 関連する課題 (issue 番号と課題名)
<!-- #[数字]でリンクすることができる。 -->
- #50 

## :cyclone: 具体的にやったこと

- 英数字と_のみ使用可に変更

## :cyclone: 確認前のチェック事項

- [x] 適切なコーディングルールの下で記述がされているか

## :cyclone: 画像や動画 (あれば)

- 
![simulator_screenshot_84A15C1D-EC14-46D4-97FD-1F07A3ED537B](https://github.com/Ktomoya912/reelproject/assets/107535701/430c4399-9ed6-4956-bec8-9bdabc5ea832)

