### PR TITLE
完了画面にて、お問合せボタンの表示の有無

### DIFF
--- a/lib/component/finishScreen/finishScreen.dart
+++ b/lib/component/finishScreen/finishScreen.dart
@@ -34,7 +34,11 @@ class FinishScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final store = Provider.of<ChangeGeneralCorporation>(context);
+    StatelessWidget questionButtonWidget = Container(); //お問合せボタンのWidget
+    //直前のページがお問合せである場合、完了ページではお問合せボタンを表示しない
+    if (this.appbarText != "問い合わせ") {
+      questionButtonWidget = QuestionButton();
+    }
     return Scaffold(
       appBar: TitleAppBar(title: appbarText),
       body: Center(
@@ -95,31 +99,45 @@ class FinishScreen extends StatelessWidget {
             const SizedBox(
               height: 30,
             ),
-            OutlinedButton(
-              //ボタン設置
-              onPressed: () {
-                // ボタンが押されたときの処理をここに追加予定
-                Navigator.of(context).push(
-                  MaterialPageRoute(builder: (context) => const AskPage()),
-                );
-              },
-
-              style: OutlinedButton.styleFrom(
-                //下線付きボタンにするためoutlinedbuttonにしている
-                side: BorderSide.none, //ここで周りの線を消している
-              ),
-              child: Text("お問い合わせ",
-                  style: TextStyle(
-                    fontSize: 17,
-                    color: store.mainColor,
-                    fontWeight: FontWeight.bold,
-                    decoration: TextDecoration.underline,
-                  )),
-            ),
+            questionButtonWidget,
           ],
         ),
       ),
       bottomNavigationBar: const NormalBottomAppBar(),
+    );
+  }
+}
+
+//お問合せボタンコンポーネント
+class QuestionButton extends StatelessWidget {
+  const QuestionButton({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final store = Provider.of<ChangeGeneralCorporation>(context); //プロバイダ
+    return OutlinedButton(
+      //ボタン設置
+      onPressed: () {
+        // ボタンが押されたときの処理をここに追加予定
+        Navigator.pop(context);
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (context) => const AskPage()),
+        );
+      },
+
+      style: OutlinedButton.styleFrom(
+        //下線付きボタンにするためoutlinedbuttonにしている
+        side: BorderSide.none, //ここで周りの線を消している
+      ),
+      child: Text("お問い合わせ",
+          style: TextStyle(
+            fontSize: 17,
+            color: store.mainColor,
+            fontWeight: FontWeight.bold,
+            decoration: TextDecoration.underline,
+          )),
     );
   }
 }

--- a/lib/page/login/new_menber_company.dart
+++ b/lib/page/login/new_menber_company.dart
@@ -230,6 +230,7 @@ class NewMemberCompanyState extends State<NewMemberCompany> {
             ElevatedButton(
               onPressed: () {
                 // ログインボタンが押されたときの処理をここに追加予定
+                Navigator.pop(context); //pop
                 Navigator.push(
                   context,
                   // MaterialPageRoute(builder: (context) => Home()),

--- a/lib/page/login/new_menber_general.dart
+++ b/lib/page/login/new_menber_general.dart
@@ -185,6 +185,7 @@ class NewMemberGeneralState extends State<NewMemberGeneral> {
             ElevatedButton(
               onPressed: () {
                 // ログインボタンが押されたときの処理をここに追加予定
+                Navigator.pop(context); //pop
                 Navigator.push(
                   context,
                   // MaterialPageRoute(builder: (context) => Home()),


### PR DESCRIPTION
## :cyclone: 関連する課題 (issue 番号と課題名)
<!-- #[数字]でリンクすることができる。 -->
- #52

## :cyclone: 具体的にやったこと

- インスタンス化時に、現在表示しているページを判断しお問合せページへの移動ボタン表示の有無を決定するようにした。

## :cyclone: 確認前のチェック事項

- [x] 適切なコーディングルールの下で記述がされているか

## :cyclone: 画像や動画 (あれば)

- here

## :cyclone: 課題のうち、やっていないこと（あれば）

- here


## :cyclone: 詰まっている箇所 (あれば)

- here
