### PR TITLE
投稿料金選択画面作成

### DIFF
--- a/lib/page/mypage/apply_post/event_fee_select.dart
+++ b/lib/page/mypage/apply_post/event_fee_select.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:reelproject/component/appbar/title_appbar.dart';
+import 'package:provider/provider.dart';
+//import '/provider/change_general_corporation.dart';
+//import "package:reelproject/component/button/SelectFeeButton.dart";
+
+//イベント広告掲載プロバイダ
+class EventApplyPostDetail with ChangeNotifier {
+  String eventFee = ""; //掲載プラン
+  //掲載プラン変更
+  void changeEventFee(String feeTitle) {
+    eventFee = feeTitle;
+    notifyListeners();
+  }
+}
+
+class EventFeeSelect extends StatefulWidget {
+  const EventFeeSelect({super.key});
+
+  @override
+  State<EventFeeSelect> createState() => _EventFeeSelectState();
+}
+
+class _EventFeeSelectState extends State<EventFeeSelect> {
+  @override
+  Widget build(BuildContext context) {
+    MediaQueryData mediaQueryData = MediaQuery.of(context); //画面サイズ取得
+    //final store = Provider.of<ChangeGeneralCorporation>(context); //プロバイダ
+
+    //横画面サイズにより幅設定
+    double widthBlank = (mediaQueryData.size.width / 2) - 300;
+    if (widthBlank < 0) {
+      widthBlank = 0;
+    }
+    double width = mediaQueryData.size.width - (widthBlank * 2);
+
+    double height = mediaQueryData.size.height * 0.75;
+    if (height < 500) {
+      height = 500;
+    }
+
+    return ChangeNotifierProvider(
+        create: (context) => EventApplyPostDetail(),
+        child: Builder(builder: (BuildContext context) {
+          return Scaffold(
+            appBar: const TitleAppBar(
+              title: "イベント掲載料金プラン",
+              jedgeBuck: true,
+            ),
+            body: SingleChildScrollView(
+                child: Center(
+              child: SizedBox(
+                height: height,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    //SizedBox(height: width / 20), //空白
+                    SelectFeeButton(
+                      width: width,
+                      title: "1回の掲載料金",
+                      titleColor: Colors.blue,
+                      textWidget: const Text('30,000円',
+                          style: TextStyle(
+                              color: Colors.black,
+                              fontSize: 30,
+                              fontWeight: FontWeight.bold)),
+                    ),
+                    //SizedBox(height: width / 10), //空白
+                    SelectFeeButton(
+                      width: width,
+                      title: "イベント+求人広告掲載プラン",
+                      titleColor: Colors.green[300]!,
+                      textWidget: const Column(
+                        children: [
+                          Text('+ 20,000円',
+                              style: TextStyle(
+                                  color: Colors.black,
+                                  fontSize: 30,
+                                  fontWeight: FontWeight.bold)),
+                          Text('で3か月求人掲載可能',
+                              style: TextStyle(
+                                color: Colors.black,
+                                fontSize: 13,
+                              )),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            children: [
+                              Text('合計',
+                                  style: TextStyle(
+                                      color: Colors.black,
+                                      fontSize: 15,
+                                      fontWeight: FontWeight.bold)),
+                              SizedBox(width: 10), //空白
+                              Text('50,000',
+                                  style: TextStyle(
+                                      color: Colors.black,
+                                      fontSize: 30,
+                                      fontWeight: FontWeight.bold,
+                                      decoration: TextDecoration.underline, //下線
+                                      decorationColor: Colors.lightGreen, //下線色
+                                      decorationThickness: 4 // 下線の太さの設定
+                                      )),
+                              Text('円',
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontSize: 30,
+                                    fontWeight: FontWeight.bold,
+                                  )),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            )),
+          );
+        }));
+  }
+}
+
+class SelectFeeButton extends StatelessWidget {
+  const SelectFeeButton({
+    super.key,
+    required this.width,
+    required this.title,
+    required this.titleColor,
+    required this.textWidget,
+  });
+
+  final double width;
+  //タイトル
+  final String title;
+  final Color titleColor;
+  //下文字
+  final Widget textWidget;
+
+  @override
+  Widget build(BuildContext context) {
+    final eventStore = Provider.of<EventApplyPostDetail>(context); //プロバイダ
+    //final jobStore = Provider.of<JobApplyPostDetail>(context); //プロバイダ
+    return InkWell(
+      onTap: () => {
+        eventStore.changeEventFee(title),
+      },
+      child:
+          //内部
+          Column(
+        children: [
+          Container(
+            //padding: const EdgeInsets.all(20),
+            alignment: Alignment.bottomCenter, //下ぞろえ
+            //影
+            decoration: const BoxDecoration(
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.grey, //色
+                  //spreadRadius: 5,//拡散
+                  blurRadius: 5, //ぼかし
+                  offset: Offset(3, 3), //影の位置
+                ),
+              ],
+              color: Colors.white,
+            ),
+            width: width * 0.7,
+            //height: width * 0.7 / 2.5,
+            child: Column(
+              children: [
+                //上枠
+                Container(
+                  width: width * 0.7,
+                  height: width * 0.7 / 10,
+                  color: titleColor,
+                  child: Center(
+                    child: Text(title,
+                        style:
+                            const TextStyle(color: Colors.white, fontSize: 15)),
+                  ),
+                ),
+                //下文字
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: textWidget,
+                ),
+                Container(
+                  width: width * 0.7 * 0.55,
+                  height: width * 0.7 / 3 * 0.3,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(40),
+                    color: titleColor,
+                  ),
+                  child: const Center(
+                    child: Text("このプランで進める",
+                        style: TextStyle(color: Colors.white, fontSize: 15)),
+                  ),
+                ),
+                SizedBox(height: width / 40), //空白
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/page/mypage/apply_post/job_fee_select.dart
+++ b/lib/page/mypage/apply_post/job_fee_select.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:reelproject/component/appbar/title_appbar.dart';
+import 'package:provider/provider.dart';
+//import '/provider/change_general_corporation.dart';
+//import "package:reelproject/component/button/SelectFeeButton.dart";
+
+//イベント広告掲載プロバイダ
+class JobApplyPostDetail with ChangeNotifier {
+  String jobFee = ""; //掲載プラン
+  //掲載プラン変更
+  void changeJobFee(String feeTitle) {
+    jobFee = feeTitle;
+    notifyListeners();
+  }
+
+  //掲載期間
+  int jobPeriod = 1;
+  //掲載期間変更
+  void changeJobPeriod(int period) {
+    jobPeriod = period;
+    notifyListeners();
+  }
+}
+
+class JobFeeSelect extends StatefulWidget {
+  const JobFeeSelect({super.key});
+
+  @override
+  State<JobFeeSelect> createState() => _JobFeeSelectState();
+}
+
+class _JobFeeSelectState extends State<JobFeeSelect> {
+  @override
+  Widget build(BuildContext context) {
+    MediaQueryData mediaQueryData = MediaQuery.of(context); //画面サイズ取得
+    //final store = Provider.of<ChangeGeneralCorporation>(context); //プロバイダ
+
+    //横画面サイズにより幅設定
+    double widthBlank = (mediaQueryData.size.width / 2) - 300;
+    if (widthBlank < 0) {
+      widthBlank = 0;
+    }
+    double width = mediaQueryData.size.width - (widthBlank * 2);
+    double height = mediaQueryData.size.height * 0.75;
+    if (height < 500) {
+      height = 500;
+    }
+
+    return ChangeNotifierProvider(
+        create: (context) => JobApplyPostDetail(),
+        child: Builder(builder: (BuildContext context) {
+          return Scaffold(
+            appBar: const TitleAppBar(
+              title: "求人掲載料金プラン",
+              jedgeBuck: true,
+            ),
+            body: SingleChildScrollView(
+                child: Center(
+              child: SizedBox(
+                height: height,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    //SizedBox(height: width / 20), //空白
+                    SelectFeeButton(
+                      width: width,
+                      title: "1か月掲載契約",
+                      titleColor: Colors.blue,
+                      textWidget: const Text(
+                        '20,000円/月',
+                        style: TextStyle(
+                            color: Colors.black,
+                            fontSize: 30,
+                            fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    //SizedBox(height: width / 20), //空白
+                    SelectFeeButton(
+                      width: width,
+                      title: "半年以上掲載契約",
+                      titleColor: const Color.fromARGB(255, 129, 199, 193),
+                      textWidget: const Text('19,000円/月',
+                          style: TextStyle(
+                              color: Colors.black,
+                              fontSize: 30,
+                              fontWeight: FontWeight.bold)),
+                    ),
+                    //SizedBox(height: width / 20), //空白
+                    SelectFeeButton(
+                      width: width,
+                      title: "1年掲載契約",
+                      titleColor: Colors.green[300]!,
+                      textWidget: const Text('200,000円/年',
+                          style: TextStyle(
+                              color: Colors.black,
+                              fontSize: 30,
+                              fontWeight: FontWeight.bold)),
+                    ),
+                  ],
+                ),
+              ),
+            )),
+          );
+        }));
+  }
+}
+
+class SelectFeeButton extends StatefulWidget {
+  const SelectFeeButton({
+    super.key,
+    required this.width,
+    required this.title,
+    required this.titleColor,
+    required this.textWidget,
+  });
+
+  final double width;
+  //タイトル
+  final String title;
+  final Color titleColor;
+  //下文字
+  final Widget textWidget;
+
+  @override
+  State<SelectFeeButton> createState() => _SelectFeeButtonState();
+}
+
+class _SelectFeeButtonState extends State<SelectFeeButton> {
+  @override
+  Widget build(BuildContext context) {
+    //final eventStore = Provider.of<EventApplyPostDetail>(context); //プロバイダ
+    final jobStore = Provider.of<JobApplyPostDetail>(context); //プロバイダ
+
+    return InkWell(
+      onTap: () => {
+        //print(jobStore.jobPeriod),
+        jobStore.changeJobFee(widget.title), //プロバイダ変更
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            //ダイアログ表示
+            return AlertDialog(
+              content: SizedBox(
+                width: widget.width * 0.5,
+                height: 200,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    const Text(
+                      "掲載する期間を選択してください",
+                      style:
+                          TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+                    ),
+                    StatefulBuilder(
+                      builder: (BuildContext context, StateSetter setState) =>
+                          DropdownButton(
+                        value: jobStore.jobPeriod,
+                        onChanged: (int? value) {
+                          setState(() {
+                            jobStore.changeJobPeriod(value!);
+                          });
+                        },
+                        items: [
+                          for (int i = 1; i <= 12; i++)
+                            DropdownMenuItem(
+                              child: Text('$iか月'),
+                              value: i,
+                            ),
+                        ],
+                      ),
+                    ),
+                    ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.blue[400],
+                        ),
+                        onPressed: () {},
+                        child: SizedBox(
+                            width: widget.width * 0.7 * 0.35,
+                            height: widget.width * 0.7 / 3 * 0.3,
+                            child: Center(child: const Text("確定")))),
+                    ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.grey[400],
+                        ),
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
+                        child: SizedBox(
+                            width: widget.width * 0.7 * 0.35,
+                            height: widget.width * 0.7 / 3 * 0.3,
+                            child: Center(child: const Text("キャンセル")))),
+                  ],
+                ),
+              ),
+            );
+          },
+        ).then((value) => setState(() {})),
+        //ダイアログ表示
+      },
+      child:
+          //内部
+          Column(
+        children: [
+          Container(
+            //padding: const EdgeInsets.all(20),
+            alignment: Alignment.bottomCenter, //下ぞろえ
+            //影
+            decoration: const BoxDecoration(
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.grey, //色
+                  //spreadRadius: 5,//拡散
+                  blurRadius: 5, //ぼかし
+                  offset: Offset(3, 3), //影の位置
+                ),
+              ],
+              color: Colors.white,
+            ),
+            width: widget.width * 0.7,
+            //height: width * 0.7 / 2.5,
+            child: Column(
+              children: [
+                //上枠
+                Container(
+                  width: widget.width * 0.7,
+                  height: widget.width * 0.7 / 10,
+                  color: widget.titleColor,
+                  child: Center(
+                    child: Text(widget.title,
+                        style:
+                            const TextStyle(color: Colors.white, fontSize: 15)),
+                  ),
+                ),
+                //下文字
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: widget.textWidget,
+                ),
+                Container(
+                  width: widget.width * 0.7 * 0.55,
+                  height: widget.width * 0.7 / 3 * 0.3,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(40),
+                    color: widget.titleColor,
+                  ),
+                  child: const Center(
+                    child: Text("このプランで進める",
+                        style: TextStyle(color: Colors.white, fontSize: 15)),
+                  ),
+                ),
+                SizedBox(height: widget.width / 40), //空白
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/page/mypage/mypage.dart
+++ b/lib/page/mypage/mypage.dart
@@ -10,6 +10,8 @@ import 'posted_list.dart'; //投稿一覧
 import 'watch_history.dart'; //閲覧履歴
 import 'favorite_list.dart'; //お気に入りリスト
 import 'no_post_list.dart'; //投稿なしリスト
+import 'apply_post/event_fee_select.dart'; //イベント掲載料金プラン
+import 'apply_post/job_fee_select.dart'; //イベント掲載料金プラン
 
 @RoutePage()
 class MyPageRouterPage extends AutoRouter {
@@ -114,7 +116,7 @@ class ScrollMyPageDetail extends StatelessWidget {
       {
         "title": "広告投稿",
         "icon": Icons.post_add,
-        "push": ApplyHist(),
+        "push": EventFeeSelect(),
       },
       {
         "title": "投稿一覧",
@@ -129,7 +131,7 @@ class ScrollMyPageDetail extends StatelessWidget {
       {
         "title": "振込口座確認",
         "icon": Icons.request_quote,
-        "push": ApplyHist(),
+        "push": JobFeeSelect(),
       },
     ],
     //メニュー


### PR DESCRIPTION
## :cyclone: 関連する課題 (issue 番号と課題名)
<!-- #[数字]でリンクすることができる。 -->
- here

## :cyclone: 具体的にやったこと

- 掲載料金決定画面を作成
- イベントの画面はマイページの投稿ボタンに設定している
- しかし、求人の選択画面に関しては、鎌田君の担当しているオーバーレイがまだ提出されていないため、口座確認ボタンに割り当てている。

## :cyclone: 確認前のチェック事項

- [x] 適切なコーディングルールの下で記述がされているか

## :cyclone: 画像や動画 (あれば)

- here

## :cyclone: 課題のうち、やっていないこと（あれば）

- here


## :cyclone: 詰まっている箇所 (あれば)

- here
