### PR TITLE
event_deatailをコンポーネント化しevent_post_detailにした

### DIFF
--- a/lib/component/listView/event_advertisment_list.dart
+++ b/lib/component/listView/event_advertisment_list.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '/provider/change_general_corporation.dart';
-import 'package:reelproject/page/event/event_detail.dart';
+import 'package:reelproject/page/event/event_post_detail.dart';
 
 //イベント広告リストコンポーネント
 class EventAdvertisementList extends StatelessWidget {
@@ -19,6 +19,76 @@ class EventAdvertisementList extends StatelessWidget {
   static String dayString = "開催日     : ";
   static String timeString = "開催時間 : ";
   static String placeString = "開催場所 : ";
+
+// データベースと連携させていないので現在はここでイベント詳細内容を設定
+  static Map<String, dynamic> eventDetailList = {
+    //必須
+    "title": "川上神社夏祭り", //タイトル
+    //詳細
+    "detail":
+        "川上様夏祭りは香北の夏の風物詩ともいえるお祭で、ビアガーデンや各種団体による模擬店、ステージイベントなどが行われ、毎年市内外から多くの見物客が訪れます。\n \n ステージイベント、宝さがし、鎮守の杜のびらふマルシェなど、子どもから大人まで誰でも楽しめるイベント内容が盛りだくさん！",
+    "day": ["2021年8月1日", "2021年8月2日", "2021年8月2日"], //日付
+    "time": ["10時00分~20時00分", "10時00分~20時00分", "10時00分~20時00分"], //時間
+    //開催場所
+    "postalNumber": ["781-5101", "781-5101", "781-5101"], //郵便番号
+    "prefecture": ["高知県", "高知県", "高知県"], //都道府県
+    "city": ["香美市", "香美市", "香美市"], //市町村
+    "houseNumber": ["川上町", "川上町", "土佐山田町"], //番地・建物名
+
+    //その他(任意)
+    "tag": [
+      "イベント",
+      "夏祭り",
+      "花火",
+      "香美市",
+      "イベント",
+    ], //ハッシュタグ
+    "phone": "0887-00-0000", //電話番号
+    "mail": "conf@gmai.com", //メールアドレス
+    "url": "https://www.city.kami.lg.jp/", //URL
+    "fee": "1000", //参加費
+    "Capacity": "100", //定員
+    "notes": "駐車場はありません。", //注意事項
+    "addMessage": "test", //追加メッセージ
+
+    //レビュー
+    "reviewPoint": 4.5, //評価
+    //星の割合(前から1,2,3,4,5)
+    "ratioStarReviews": [0.03, 0.07, 0.1, 0.3, 0.5],
+    //レビュー数
+    "reviewNumber": 100,
+    //レビュー内容
+    "review": [
+      {
+        "reviewerName": "名前aiueo",
+        //"reviewerImage" : "test"   //予定
+        "reviewPoint": 3, //レビュー点数
+        "reviewDetail": "testfffff\n\n\n\n\n\n\nfffff", //レビュー内容
+        "reviewDate": "2021年8月1日", //レビュー日時
+      },
+      {
+        "reviewerName": "名前kakikukeko",
+        //"reviewerImage" : "test"   //予定
+        "reviewPoint": 3, //レビュー点数
+        "reviewDetail": "test", //レビュー内容
+        "reviewDate": "2021年8月1日", //レビュー日時
+      },
+      {
+        "reviewerName": "名前sasisuseso",
+        //"reviewerImage" : "test"   //予定
+        "reviewPoint": 3, //レビュー点数
+        "reviewDetail": "test", //レビュー内容
+        "reviewDate": "2021年8月1日", //レビュー日時
+      }
+    ],
+
+    //この広告を投稿したか
+    "postJedge": true,
+
+    //掲載期間
+    "postTerm": "2023年12月10日"
+  };
+// -------------------------------------------------------------------------------
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +124,7 @@ class EventAdvertisementList extends StatelessWidget {
                       PageRouteBuilder(
                           pageBuilder:
                               (context, animation, secondaryAnimation) =>
-                                  const EventDetail()));
+                                  EventPostDetail(eventList: eventDetailList)));
                   //タップ処理
                 },
                 child:

--- a/lib/page/event/event_post_detail.dart
+++ b/lib/page/event/event_post_detail.dart
@@ -5,84 +5,29 @@ import 'package:reelproject/component/appbar/detail_appbar.dart';
 import '/provider/change_general_corporation.dart';
 import 'package:reelproject/component/listView/review.dart';
 
-class EventDetail extends StatefulWidget {
-  const EventDetail({super.key});
+class EventPostDetail extends StatefulWidget {
+  const EventPostDetail({
+    super.key,
+    required this.eventList,
+  });
+
+  final Map<String, dynamic> eventList;
 
   @override
-  State<EventDetail> createState() => _EventDetailState();
+  State<EventPostDetail> createState() => _EventPostDetailState();
 }
 
-class _EventDetailState extends State<EventDetail> {
+class _EventPostDetailState extends State<EventPostDetail> {
+  late Map<String, dynamic> eventDetailList;
+
+  @override
+  void initState() {
+    super.initState();
+    eventDetailList = widget.eventList;
+  }
+
   //求人広告のリスト
   //titleに文字数制限を設ける
-  static Map<String, dynamic> eventDetailList = {
-    //必須
-    "title": "川上神社夏祭り", //タイトル
-    //詳細
-    "detail":
-        "川上様夏祭りは香北の夏の風物詩ともいえるお祭で、ビアガーデンや各種団体による模擬店、ステージイベントなどが行われ、毎年市内外から多くの見物客が訪れます。\n \n ステージイベント、宝さがし、鎮守の杜のびらふマルシェなど、子どもから大人まで誰でも楽しめるイベント内容が盛りだくさん！",
-    "day": ["2021年8月1日", "2021年8月2日", "2021年8月2日"], //日付
-    "time": ["10時00分~20時00分", "10時00分~20時00分", "10時00分~20時00分"], //時間
-    //開催場所
-    "postalNumber": ["781-5101", "781-5101", "781-5101"], //郵便番号
-    "prefecture": ["高知県", "高知県", "高知県"], //都道府県
-    "city": ["香美市", "香美市", "香美市"], //市町村
-    "houseNumber": ["川上町", "川上町", "土佐山田町"], //番地・建物名
-
-    //その他(任意)
-    "tag": [
-      "イベント",
-      "夏祭り",
-      "花火",
-      "香美市",
-      "イベント",
-    ], //ハッシュタグ
-    "phone": "0887-00-0000", //電話番号
-    "mail": "conf@gmai.com", //メールアドレス
-    "url": "https://www.city.kami.lg.jp/", //URL
-    "fee": "1000", //参加費
-    "Capacity": "100", //定員
-    "notes": "駐車場はありません。", //注意事項
-    "addMessage": "test", //追加メッセージ
-
-    //レビュー
-    "reviewPoint": 4.5, //評価
-    //星の割合(前から1,2,3,4,5)
-    "ratioStarReviews": [0.03, 0.07, 0.1, 0.3, 0.5],
-    //レビュー数
-    "reviewNumber": 100,
-    //レビュー内容
-    "review": [
-      {
-        "reviewerName": "名前aiueo",
-        //"reviewerImage" : "test"   //予定
-        "reviewPoint": 3, //レビュー点数
-        "reviewDetail": "testfffff\n\n\n\n\n\n\nfffff", //レビュー内容
-        "reviewDate": "2021年8月1日", //レビュー日時
-      },
-      {
-        "reviewerName": "名前kakikukeko",
-        //"reviewerImage" : "test"   //予定
-        "reviewPoint": 3, //レビュー点数
-        "reviewDetail": "test", //レビュー内容
-        "reviewDate": "2021年8月1日", //レビュー日時
-      },
-      {
-        "reviewerName": "名前sasisuseso",
-        //"reviewerImage" : "test"   //予定
-        "reviewPoint": 3, //レビュー点数
-        "reviewDetail": "test", //レビュー内容
-        "reviewDate": "2021年8月1日", //レビュー日時
-      }
-    ],
-
-    //この広告を投稿したか
-    "postJedge": true,
-
-    //掲載期間
-    "postTerm": "2023年12月10日"
-  };
-
   bool favoriteJedge = false; //お気に入り判定
 
   //二度同じ場所を表示しないように制御する関数

--- a/lib/page/home/home.dart
+++ b/lib/page/home/home.dart
@@ -8,7 +8,7 @@ import 'package:reelproject/page/mypage/posted_list.dart';
 import 'package:reelproject/page/mypage/watch_history.dart';
 import 'package:reelproject/page/mypage/favorite_list.dart';
 import 'package:reelproject/page/job/job_detail.dart';
-import 'package:reelproject/page/event/event_detail.dart';
+// import 'package:reelproject/page/event/event_post_detail.dart';
 
 @RoutePage()
 class HomeRouterPage extends AutoRouter {


### PR DESCRIPTION
## :cyclone: 関連する課題 (issue 番号と課題名)
<!-- #[数字]でリンクすることができる。 -->
- here

## :cyclone: 具体的にやったこと

- event_deatailをコンポーネント化しevent_post_detailにした、
- またその際にmap型を渡す動作をevent_advertisment_listの内容を修正

## :cyclone: 確認前のチェック事項

- [] 適切なコーディングルールの下で記述がされているか

## :cyclone: 画像や動画 (あれば)

- here

## :cyclone: 課題のうち、やっていないこと（あれば）

- データベースから情報を取得する機能をまだつけていないので、現在はevent_advertisment_list内に詳細情報をそのまま記述している


## :cyclone: 詰まっている箇所 (あれば)

- here
