### PR TITLE
グラフの大きさが環境が違う際に正常になるように変更した

### DIFF
--- a/lib/page/mypage/impression.dart
+++ b/lib/page/mypage/impression.dart
@@ -140,7 +140,8 @@ class ScrollImpressionsDetail extends StatelessWidget {
             Column(
               children: [
                 SizedBox(
-                  width: MediaQuery.of(context).size.width / 1.02,
+                  width: 400,
+
 
                   // child:Card(
                   child: Column(
@@ -171,7 +172,7 @@ class ScrollImpressionsDetail extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 SizedBox(
-                  width: MediaQuery.of(context).size.width / 3.5,
+                  width: 110,
                   child: Column(
                     children: [
                       MyPieChart(
@@ -192,7 +193,7 @@ class ScrollImpressionsDetail extends StatelessWidget {
                 ),
                 const Padding(padding: EdgeInsets.all(10)),
                 SizedBox(
-                  width: MediaQuery.of(context).size.width / 3.5,
+                  width: 110,
                   child: Column(
                     children: [
                       MyPieChart(
@@ -213,7 +214,7 @@ class ScrollImpressionsDetail extends StatelessWidget {
                 ),
                 const Padding(padding: EdgeInsets.all(10)),
                 SizedBox(
-                  width: MediaQuery.of(context).size.width / 3.5,
+                  width: 110,
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     crossAxisAlignment: CrossAxisAlignment.center,
@@ -268,8 +269,8 @@ class MyPieChart extends StatelessWidget {
             animationDuration: const Duration(milliseconds: 800),
             chartLegendSpacing: 64,
             chartRadius: mainflag
-                ? MediaQuery.of(context).size.width / 2.9
-                : MediaQuery.of(context).size.width / 4.9,
+                ? 150
+                : MediaQuery.of(context).size.width * MediaQuery.of(context).size.height / 5250,
             colorList: const [
               Color(0xff6c5ce7),
               Color(0xff0984e3),


### PR DESCRIPTION
## :cyclone: 関連する課題 (issue 番号と課題名)
<!-- #[数字]でリンクすることができる。 -->
- グラフの大きさの整備

## :cyclone: 具体的にやったこと

- グラフの大きさがブラウザやアプリと違うのを違和感がないように修正した

## :cyclone: 確認前のチェック事項

- [x] 適切なコーディングルールの下で記述がされているか

## :cyclone: 画像や動画 (あれば)

- 
![Simulator Screenshot - iPhone 15 Pro - 2024-01-04 at 16 27 05](https://github.com/Ktomoya912/reelproject/assets/107535701/0e39d7fd-a9d0-4503-a614-94f2d6c14707)
<img width="1440" alt="スクリーンショット 2024-01-04 16 28 46" src="https://github.com/Ktomoya912/reelproject/assets/107535701/ec26a5af-ba85-42dd-83ee-93731a6e5ffb">


